### PR TITLE
Enhancement [#11]: Use Theme's icon color

### DIFF
--- a/resources/views/navigation.blade.php
+++ b/resources/views/navigation.blade.php
@@ -1,5 +1,5 @@
 <router-link tag="h3" :to="{name: 'tinker-tool'}" class="cursor-pointer flex items-center font-normal dim text-white mb-6 text-base no-underline">
-    <svg class="sidebar-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path fill="#B3C1D1" d="M6.47 9.8A5 5 0 0 1 .2 3.22l3.95 3.95 2.82-2.83L3.03.41a5 5 0 0 1 6.4 6.68l10 10-2.83 2.83L6.47 9.8z"/></svg>
+    <svg class="sidebar-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path fill="var(--sidebar-icon)" d="M6.47 9.8A5 5 0 0 1 .2 3.22l3.95 3.95 2.82-2.83L3.03.41a5 5 0 0 1 6.4 6.68l10 10-2.83 2.83L6.47 9.8z"/></svg>
     <span class="sidebar-label">
         Tinker
     </span>


### PR DESCRIPTION
This replaces the hardcoded icon color with a customizable template color by setting `fill="var(--sidebar-icon)"` on the svg icon.
Closes #11.